### PR TITLE
Package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +24,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -50,6 +69,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "async_io_utilities"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b20cffc5590f4bf33f05f97a3ea587feba9c50d20325b401daa096b92ff7da0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "async_zip"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a36d43bdefc7215b2b3a97edd03b1553b7969ad76551025eedd3b913c645f6e"
+dependencies = [
+ "async-compression",
+ "async_io_utilities",
+ "chrono",
+ "crc32fast",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -241,18 +283,26 @@ dependencies = [
 name = "cloudformatious-cli"
 version = "0.1.2"
 dependencies = [
+ "async_zip",
  "atty",
  "aws_sso_flow",
+ "base64",
+ "chrono",
  "clap",
  "clap_complete",
  "cloudformatious",
  "colored",
  "futures-util",
+ "md5",
  "rusoto_cloudformation",
  "rusoto_core 0.46.0",
  "rusoto_credential 0.46.0",
+ "rusoto_s3",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -457,6 +507,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -866,6 +926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1275,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_s3"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc3f56f14ccf91f880b9a9c2d0556d8523e8c155041c54db155b384a1dd1119"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core 0.46.0",
+ "xml-rs",
+]
+
+[[package]]
 name = "rusoto_signature"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,18 +1462,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1428,6 +1510,19 @@ dependencies = [
  "itoa 0.4.8",
  "serde",
  "url",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+dependencies = [
+ "indexmap",
+ "itoa 1.0.3",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1610,18 +1705,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1694,9 +1789,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1704,7 +1799,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1805,6 +1899,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ rusoto_s3 = "0.46.0"
 serde_json = "1.0.85"
 serde_yaml = "0.9.13"
 tempfile = "3.3.0"
-tokio = { version = "1.21.0", features = ["fs", "io-util", "macros"] }
+tokio = { version = "1.21.0", features = ["fs", "io-std", "io-util", "macros"] }
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,23 @@ name = "cloudformatious"
 path = "src/main.rs"
 
 [dependencies]
+async_zip = { version = "0.0.9", default-features = false, features = ["deflate"] }
 atty = "0.2.14"
 aws_sso_flow = { version = "0.2.0", default-features = false, features = ["native-tls", "rusoto"] }
+base64 = "0.13.0"
+chrono = { version = "0.4.22", default-features = false }
 clap = { version = "3.2.20", features = ["derive", "env"] }
 clap_complete = "3.2.4"
 cloudformatious = "0.1.0"
 colored = "2.0.0"
 futures-util = "0.3.24"
+md5 = "0.7.0"
 rusoto_cloudformation = "0.46.0"
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
+rusoto_s3 = "0.46.0"
 serde_json = "1.0.85"
-tokio = { version = "1.21.0", features = ["macros"] }
+serde_yaml = "0.9.13"
+tempfile = "3.3.0"
+tokio = { version = "1.21.0", features = ["fs", "io-util", "macros"] }
+tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,7 @@
 mod apply_stack;
 mod completions;
 mod delete_stack;
+mod package;
 
 use rusoto_core::Region;
 
@@ -11,6 +12,7 @@ pub enum Command {
     Completions(self::completions::Args),
     ApplyStack(self::apply_stack::Args),
     DeleteStack(self::delete_stack::Args),
+    UnstablePackage(self::package::Args),
 }
 
 pub async fn main(region: Option<Region>, command: Command) -> Result<(), Error> {
@@ -18,5 +20,6 @@ pub async fn main(region: Option<Region>, command: Command) -> Result<(), Error>
         Command::Completions(args) => self::completions::main(args),
         Command::ApplyStack(args) => self::apply_stack::main(region, args).await,
         Command::DeleteStack(args) => self::delete_stack::main(region, args).await,
+        Command::UnstablePackage(args) => self::package::main(region, args).await,
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,6 @@
-pub mod apply_stack;
-pub mod completions;
-pub mod delete_stack;
+mod apply_stack;
+mod completions;
+mod delete_stack;
 
 use rusoto_core::Region;
 

--- a/src/command/apply_stack.rs
+++ b/src/command/apply_stack.rs
@@ -10,7 +10,7 @@ use std::{
 use cloudformatious::{
     ApplyStackError, ApplyStackInput, Capability, CloudFormatious as _, Parameter, TemplateSource,
 };
-use rusoto_cloudformation::Tag;
+use rusoto_cloudformation::{CloudFormationClient, Tag};
 use rusoto_core::Region;
 
 use crate::{
@@ -137,7 +137,7 @@ impl TryFrom<Args> for ApplyStackInput {
 pub async fn main(region: Option<Region>, args: Args) -> Result<(), Error> {
     let quiet = args.quiet;
 
-    let client = crate::get_client(region).await?;
+    let client = crate::get_client(CloudFormationClient::new_with, region).await?;
     let mut apply = client.apply_stack(args.try_into()?);
 
     let change_set = apply.change_set().await.map_err(Error::other)?;

--- a/src/command/delete_stack.rs
+++ b/src/command/delete_stack.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use cloudformatious::{CloudFormatious as _, DeleteStackError, DeleteStackInput};
+use rusoto_cloudformation::CloudFormationClient;
 use rusoto_core::Region;
 
 use crate::{
@@ -100,7 +101,7 @@ impl TryFrom<Args> for DeleteStackInput {
 pub async fn main(region: Option<Region>, args: Args) -> Result<(), Error> {
     let quiet = args.quiet;
 
-    let client = get_client(region).await?;
+    let client = get_client(CloudFormationClient::new_with, region).await?;
     let mut delete = client.delete_stack(args.try_into()?);
     let sizing = Sizing::default();
 

--- a/src/command/package.rs
+++ b/src/command/package.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use rusoto_core::Region;
+
+use crate::{package, s3, Error, Template};
+
+/// Package local assets referenced in a CloudFormation template.
+///
+/// This scans specific properties for specific resource types for paths that exist locally. If
+/// found, the referenced path is uploaded to an S3 bucket. Paths may be absolute or relative.
+/// Relative paths are resolved relative to the template directory. If the path points to a file it
+/// will be uploaded as-is. If it's a directory, it will be zipped and the `.zip` file will be
+/// uploaded. Nothing is uploaded if a file already exists with the same name and MD5 checksum.
+///
+/// Local artifacts can be referenced in the following places:
+///
+/// - `AWS::Lambda::Function`: `Code` property.
+#[derive(Debug, clap::Parser)]
+pub struct Args {
+    /// The name of the S3 bucket to which artifacts will be uploaded.
+    #[clap(long)]
+    s3_bucket: String,
+
+    /// A prefix under which the uploaded artifacts will be stored.
+    #[clap(long)]
+    s3_prefix: Option<String>,
+
+    /// Path to the template to scan for local artifacts.
+    template_path: PathBuf,
+}
+
+pub async fn main(region: Option<Region>, args: Args) -> Result<(), Error> {
+    let client = s3::Client::new(region).await?;
+    let mut template = Template::open(args.template_path).await?;
+
+    let targets = package::targets(&mut template);
+
+    package::process(&client, &args.s3_bucket, args.s3_prefix.as_deref(), targets)
+        .await
+        .map_err(Error::other)?;
+
+    println!("{}", template);
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,16 @@ mod client;
 mod command;
 mod error;
 mod fmt;
+mod package;
+mod s3;
+mod template;
 
 use std::process;
 
 use clap::Parser;
 use rusoto_core::Region;
 
-use self::{client::get_client, error::Error};
+use self::{client::get_client, error::Error, template::Template};
 
 /// A CloudFormation CLI that won't make you cry.
 ///

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,0 +1,174 @@
+use std::{collections::HashMap, fmt, iter::FromIterator, path::PathBuf};
+
+use async_zip::{write::ZipFileWriter, Compression, ZipEntryBuilder};
+use chrono::{DateTime, Utc};
+use futures_util::{stream, TryStreamExt};
+use serde_yaml::Value as YamlValue;
+use tokio::{
+    fs::{self, File},
+    io::{self, AsyncSeekExt},
+};
+
+use crate::{s3, Error, Template};
+
+#[derive(Debug)]
+pub struct PackageableProperty {
+    resource_type: &'static str,
+    path: &'static [&'static str],
+    s3_ref: fn(String, s3::UploadOutput) -> serde_yaml::Value,
+}
+
+const PACKAGEABLE_PROPERTIES: &[PackageableProperty] = &[PackageableProperty {
+    resource_type: "AWS::Lambda::Function",
+    path: &["Code"],
+    s3_ref: |bucket, upload| {
+        serde_yaml::Mapping::from_iter([
+            (
+                serde_yaml::Value::String("S3Bucket".to_string()),
+                serde_yaml::Value::String(bucket),
+            ),
+            (
+                serde_yaml::Value::String("S3Key".to_string()),
+                serde_yaml::Value::String(upload.key),
+            ),
+        ])
+        .into()
+    },
+}];
+
+pub struct Target<'y> {
+    resource_id: &'y str,
+    property: &'static PackageableProperty,
+    target: &'y mut YamlValue,
+    path: PathBuf,
+}
+
+pub fn targets(template: &mut Template) -> impl Iterator<Item = Target<'_>> + '_ {
+    // Build a map of packageable property for easy lookup
+    let packageable_properties: HashMap<_, _> = PACKAGEABLE_PROPERTIES
+        .iter()
+        .map(|prop| (prop.resource_type, prop))
+        .collect();
+
+    let package_dir = template
+        .path()
+        .parent()
+        .expect("file path must have parent")
+        .to_path_buf();
+
+    template.resources_mut().filter_map(move |resource| {
+        let property = packageable_properties.get(resource.resource_type())?;
+        let (resource_id, _, properties) = resource.into_parts_mut();
+        let target = property
+            .path
+            .iter()
+            .try_fold(properties, |props, key| props.get_mut(key))?;
+        let path = package_dir.join(target.as_str()?);
+
+        Some(Target {
+            resource_id,
+            property,
+            target,
+            path,
+        })
+    })
+}
+
+pub async fn process(
+    client: &s3::Client,
+    s3_bucket: &str,
+    s3_prefix: Option<&str>,
+    targets: impl IntoIterator<Item = Target<'_>>,
+) -> Result<(), Error> {
+    stream::iter(targets.into_iter().map(Ok::<_, Error>))
+        .try_for_each_concurrent(None, |target| async move {
+            let file = package_zip(&target).await?;
+
+            let upload = client
+                .upload(s3::UploadRequest {
+                    bucket: s3_bucket,
+                    prefix: s3_prefix,
+                    file,
+                })
+                .await
+                .or_else(|error| upload_err(&target, error))?;
+
+            *target.target = (target.property.s3_ref)(s3_bucket.to_string(), upload);
+
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+
+async fn package_zip(target: &Target<'_>) -> Result<File, Error> {
+    let metadata = match fs::metadata(&target.path).await {
+        Ok(metadata) => metadata,
+        Err(error) => return upload_err(target, error),
+    };
+
+    let mut zip = File::from_std(
+        tokio::task::spawn_blocking(tempfile::tempfile)
+            .await
+            .unwrap_or_else(|error| std::panic::resume_unwind(error.into_panic()))
+            .or_else(|error| {
+                upload_err(target, format!("couldn't create temporary file: {error}"))
+            })?,
+    );
+    let mut writer = ZipFileWriter::new(&mut zip);
+
+    if metadata.is_file() {
+        // Add the single file to the ZIP with the same file name
+        let file_name = target
+            .path
+            .file_name()
+            .expect("file must have file name")
+            .to_string_lossy()
+            .into_owned();
+
+        let mut entry_writer = writer
+            .write_entry_stream(
+                ZipEntryBuilder::new(file_name, Compression::Deflate)
+                    .last_modification_date(DateTime::<Utc>::MIN_UTC)
+                    .build(),
+            )
+            .await
+            .or_else(|error| upload_err(target, format!("couldn't write: {error}",)))?;
+
+        let mut file = io::BufReader::new(
+            File::open(&target.path)
+                .await
+                .or_else(|error| upload_err(target, format!("couldn't open: {error}")))?,
+        );
+        io::copy_buf(&mut file, &mut entry_writer)
+            .await
+            .or_else(|error| upload_err(target, format!("write error: {error}",)))?;
+        entry_writer
+            .close()
+            .await
+            .or_else(|error| upload_err(target, format!("couldn't write: {error}")))?;
+    } else if metadata.is_dir() {
+        todo!()
+    } else {
+        return upload_err(target, "not a file or directory");
+    }
+
+    writer
+        .close()
+        .await
+        .or_else(|error| upload_err(target, format!("couldn't write: {error}")))?;
+
+    zip.rewind()
+        .await
+        .or_else(|error| upload_err(target, format!("read error: {error}")))?;
+    Ok(zip)
+}
+
+fn upload_err<T>(target: &Target, error: impl fmt::Display) -> Result<T, Error> {
+    Err(Error::other(format!(
+        "couldn't upload `{}` for `{}`: {error}",
+        target.path.display(),
+        target.resource_id
+    )))
+}

--- a/src/package.rs
+++ b/src/package.rs
@@ -9,7 +9,7 @@ use tokio::{
     io::{self, AsyncSeekExt},
 };
 
-use crate::{s3, Error, Template};
+use crate::{s3, template, Error, Template};
 
 #[derive(Debug)]
 pub struct PackageableProperty {
@@ -50,11 +50,13 @@ pub fn targets(template: &mut Template) -> impl Iterator<Item = Target<'_>> + '_
         .map(|prop| (prop.resource_type, prop))
         .collect();
 
-    let package_dir = template
-        .path()
-        .parent()
-        .expect("file path must have parent")
-        .to_path_buf();
+    let package_dir = match template.source() {
+        template::Source::Path(path) => path
+            .parent()
+            .expect("file path must have a parent")
+            .to_path_buf(),
+        template::Source::Stdin => PathBuf::from(""),
+    };
 
     template.resources_mut().filter_map(move |resource| {
         let property = packageable_properties.get(resource.resource_type())?;

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,0 +1,114 @@
+use std::{convert::TryInto, path::Path};
+
+use futures_util::{StreamExt, TryStreamExt};
+use rusoto_core::Region;
+use rusoto_s3::{HeadObjectRequest, PutObjectRequest, S3Client, S3};
+use tokio::{
+    fs::File,
+    io::{AsyncSeekExt, BufReader},
+};
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+use crate::{client::get_client, Error};
+
+pub struct Client {
+    inner: rusoto_s3::S3Client,
+}
+
+impl Client {
+    pub async fn new(region: Option<Region>) -> Result<Self, Error> {
+        let inner = get_client(S3Client::new_with, region).await?;
+        Ok(Self { inner })
+    }
+
+    pub async fn upload<'a>(&self, request: UploadRequest<'a>) -> Result<UploadOutput, Error> {
+        let meta = request
+            .file
+            .metadata()
+            .await
+            .map_err(|error| Error::other(format!("couldn't stat upload package: {error}",)))?;
+
+        let mut reader = FramedRead::new(BufReader::new(request.file), BytesCodec::new());
+
+        let context = reader
+            .by_ref()
+            .try_fold(md5::Context::new(), |mut context, chunk| async move {
+                context.consume(&chunk);
+                Ok(context)
+            })
+            .await
+            .map_err(|error| Error::other(format!("couldn't read upload package: {error}",)))?;
+        let content_md5 = context.compute();
+
+        let key = Path::new(request.prefix.unwrap_or(""))
+            .join(format!("{:x}", content_md5))
+            .to_string_lossy()
+            .into_owned();
+
+        let exists = self
+            .inner
+            .head_object(HeadObjectRequest {
+                bucket: request.bucket.to_owned(),
+                key: key.clone(),
+                ..Default::default()
+            })
+            .await
+            .map(|_| true)
+            .or_else({
+                let bucket = &request.bucket;
+                let key = &key;
+                move |error| match error {
+                    rusoto_core::RusotoError::Unknown(res) if res.status.as_u16() == 404 => {
+                        Ok(false)
+                    }
+                    error => Err(Error::other(format!(
+                        "an error occurred when trying to read s3://{bucket}/{key}: {error}",
+                    ))),
+                }
+            })?;
+        if exists {
+            return Ok(UploadOutput { key });
+        }
+
+        let mut file = reader.into_inner().into_inner();
+        file.rewind()
+            .await
+            .map_err(|error| Error::other(format!("couldn't read upload package: {error}")))?;
+
+        self.inner
+            .put_object(PutObjectRequest {
+                body: Some(rusoto_s3::StreamingBody::new_with_size(
+                    FramedRead::new(BufReader::new(file), BytesCodec::new())
+                        .map_ok(|chunk| chunk.freeze()),
+                    meta.len()
+                        .try_into()
+                        .expect("file is too large for platform"),
+                )),
+                bucket: request.bucket.to_owned(),
+                content_length: Some(meta.len().try_into().expect("file is insanely large")),
+                content_md5: Some(base64::encode(&content_md5.0)),
+                key: key.clone(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| {
+                Error::other(format!(
+                    "an error occurred when uploading package to {key}: {error}",
+                ))
+            })?;
+
+        Ok(UploadOutput { key })
+    }
+}
+
+#[derive(Debug)]
+pub struct UploadRequest<'a> {
+    pub bucket: &'a str,
+    pub prefix: Option<&'a str>,
+    pub file: File,
+}
+
+#[derive(Debug)]
+pub struct UploadOutput {
+    pub key: String,
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,0 +1,177 @@
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+use serde_yaml::Value as YamlValue;
+use tokio::{fs, io};
+
+use crate::Error;
+
+pub struct Template {
+    path: PathBuf,
+    content: YamlValue,
+}
+
+pub struct ResourceMut<'t> {
+    resource_id: &'t str,
+    resource_type: &'t mut str,
+    properties: &'t mut YamlValue,
+}
+
+impl<'t> ResourceMut<'t> {
+    pub fn into_parts_mut(self) -> (&'t str, &'t mut str, &'t mut YamlValue) {
+        (self.resource_id, self.resource_type, self.properties)
+    }
+
+    pub fn resource_type(&self) -> &str {
+        &*self.resource_type
+    }
+}
+
+impl Template {
+    pub async fn open(path: PathBuf) -> Result<Self, Error> {
+        let meta = fs::metadata(&path)
+            .await
+            .map_err(ReadError::for_path(&path))?;
+        if !meta.is_file() {
+            return Err(Error::other(ReadError::new(
+                &path,
+                io::Error::new(io::ErrorKind::Other, "not a file"),
+            )));
+        }
+
+        let yaml = fs::read(&path).await.map_err(ReadError::for_path(&path))?;
+        let content = serde_yaml::from_slice(&yaml).map_err(ParseError::for_path(&path))?;
+
+        Ok(Self { path, content })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn resources_mut(&mut self) -> impl Iterator<Item = ResourceMut<'_>> {
+        self.content
+            .get_mut("Resources")
+            .and_then(YamlValue::as_mapping_mut)
+            .map(|resources| resources.iter_mut())
+            .into_iter()
+            .flatten()
+            .filter_map(|(key, val)| {
+                let resource_id = key.as_str()?;
+                let resource = val.as_mapping_mut()?;
+                let (resource_type, properties) = resource.iter_mut().fold(
+                    (None, None),
+                    |(resource_type, properties), (key, value)| {
+                        if let Some("Type") = key.as_str() {
+                            if let YamlValue::String(resource_type) = value {
+                                return (Some(resource_type), properties);
+                            }
+                        }
+                        if let Some("Properties") = key.as_str() {
+                            return (resource_type, Some(value));
+                        }
+                        (resource_type, properties)
+                    },
+                );
+                let resource_type = resource_type?;
+                let properties = properties?;
+                Some(ResourceMut {
+                    resource_id,
+                    resource_type,
+                    properties,
+                })
+            })
+    }
+}
+
+impl fmt::Display for Template {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_yaml::to_string(&self.content).expect("template was parsed so must serialize")
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct ReadError {
+    path: PathBuf,
+    error: io::Error,
+}
+
+impl ReadError {
+    fn new(path: &Path, error: io::Error) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            error,
+        }
+    }
+
+    fn for_path(path: &Path) -> impl FnOnce(io::Error) -> Self + '_ {
+        move |error| Self::new(path, error)
+    }
+}
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "couldn't read template `{}` due to: {}",
+            self.path.display(),
+            self.error
+        )
+    }
+}
+
+impl std::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+impl From<ReadError> for Error {
+    fn from(error: ReadError) -> Self {
+        Self::other(error)
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseError {
+    path: PathBuf,
+    error: serde_yaml::Error,
+}
+
+impl ParseError {
+    fn for_path(path: &Path) -> impl FnOnce(serde_yaml::Error) -> Self + '_ {
+        move |error| Self {
+            path: path.to_path_buf(),
+            error,
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "invalid template `{}`: {}",
+            self.path.display(),
+            self.error
+        )
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(error: ParseError) -> Self {
+        Self::other(error)
+    }
+}

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,3 @@
+exports.handler = async () => {
+  return 'ok'
+}

--- a/test/fixtures/lambda.yaml
+++ b/test/fixtures/lambda.yaml
@@ -1,0 +1,21 @@
+Resources:
+  Lambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code: ./index.js
+      Handler: index.handler
+      Role: !GetAtt Role.Arn
+      Runtime: nodejs16.x
+
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole


### PR DESCRIPTION
- e34cc3c **fix: reduce visibility of `command` sub-modules**

  These don't need to be `pub`.

- 64733c2 **feat: add an (unstable) `package` command**

  This offers similar functionality as `aws cloudformation package`,
  whereby local paths in certain template properties are uploaded to S3
  and replaced with a reference to the uploaded file. The new
  `lambda.yaml` fixture demonstrates this for a Lambda function.
  
  Like `aws cloudformation package`, the `package` command will print the
  modified template. The plan is to not have a separate command for this
  however, and to instead integrate packaging with `apply-stack` (hence
  the `package` command is unstable as it might not last long).
  
  Terminologically, we say that some resource properties are
  "packageable". Packageable properties are identified by resource type
  and a path into the resource properties (e.g. `AWS::Lambda::Function`
  and `["Code"]`, indicating that the `Code` property of
  `AWS::Lambda::Function`s is packageable). Packaging a template takes
  place in two phases:
  
  1. Locating "package targets" in the template. This involves visiting
     each packageable property in the template, checking if it should be
     packaged, and extracting a `package::Target`s if so. For now,
     packageable properties will be packaged if they contain a string
     value. This may end up depending on the particular `PackageableField`
     in future.
  
  2. "Processing" the targets, which involves building a zip archive of
     the local path, uploading the archive to S3, and writing the S3
     location back to the target property. Targets are processed
     concurrently. S3 objects are named as the MD5 checksum of the zip
     file, and the upload is not performed if a file already exists.

- a5c895a **feat: perform 'package' preprocessing in `apply-stack`**

  This reuses the `package` machinery to perform packaging as a
  preprecessing step in `apply-stack`. Thanks to the work on
  `unstable-package` this was very straightforward, with the only subtlety
  being the `--package-bucket` option is optional unless package targets
  are found in the template, in which case it is required.

- f67da04 **feat: add support for applying templates from STDIN**

  The `apply-stack` command now supports the common UNIX convention of
  reading from STDIN when given `-` as a path.
  
  Reading from STDIN comes with a couple of limitations/caveats:
  
  - A `--stack-name` must be specified when reading from STDIN, since we
    can't infer one from the file name.
  
  - Package targets will be resolved relative to the working directory.
