### PR TITLE
Prep release

### DIFF
--- a/.github/workflows/cache-osxcross.yaml
+++ b/.github/workflows/cache-osxcross.yaml
@@ -1,0 +1,42 @@
+# This workflow performs a cached build of osxcross. The idea is to run it on your default branch
+# (e.g. `main`) to prepare a cache that can then be consumed from other branches/tags.
+
+name: Cache osxcross
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    name: Cache osxcross
+    runs-on: ubuntu-latest
+    env:
+      SDK_VERSION: '12.3'
+    steps:
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: ${{ runner.temp }}/osxcross
+          key: osxcross-${{ runner.os }}-${{ env.SDK_VERSION }}
+      - name: Build osxcross
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update && sudo apt-get install -y \
+            clang \
+            g++ \
+            gcc \
+            libgmp-dev \
+            libmpc-dev \
+            libmpfr-dev \
+            zlib1g-dev
+
+          git clone https://github.com/tpoechtrager/osxcross "$RUNNER_TEMP/osxcross"
+
+          sdk_file="MacOSX$SDK_VERSION.sdk.tar.xz"
+          wget -nc "https://github.com/joseluisq/macosx-sdks/releases/download/$SDK_VERSION/$sdk_file" -O "$RUNNER_TEMP/osxcross/tarballs/$sdk_file"
+
+          UNATTENDED=yes "$RUNNER_TEMP/osxcross/build.sh"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  release:
+    types: published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  binaries:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [aarch64, x86_64]
+        os: [apple-darwin, unknown-linux-gnu]
+    name: Build binary (${{ matrix.os }} ${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    env:
+      SDK_VERSION: '12.3'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: ${{ matrix.arch }}-${{ matrix.os }}
+      - name: Cache osxcross
+        if: matrix.os == 'apple-darwin'
+        uses: actions/cache@v3
+        id: osxcrossCache
+        with:
+          path: ${{ runner.temp }}/osxcross
+          key: osxcross-${{ runner.os }}-${{ env.SDK_VERSION }}
+      - name: Set osxcross env
+        if: matrix.os == 'apple-darwin'
+        run: |
+          set -euo pipefail
+
+          echo "$OSXCROSS_PATH/target/bin" >> "$GITHUB_PATH"
+          echo "CARGO_TARGET_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')_APPLE_DARWIN_LINKER=$(find "$OSXCROSS_PATH/target/bin" -name '${{ matrix.arch }}-apple-darwin*-clang' -exec basename {} \;)" >> $GITHUB_ENV
+          echo "CARGO_TARGET_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')_APPLE_DARWIN_RUSTFLAGS=-Car=$(find "$OSXCROSS_PATH/target/bin" -name '${{ matrix.arch }}-apple-darwin*-ar' -exec basename {} \;),-Clink-arg=-undefined,-Clink-arg=dynamic_lookup" >> $GITHUB_ENV
+        env:
+          OSXCROSS_PATH: ${{ runner.temp }}/osxcross
+      - name: Set aarch64-unknown-linux-gnu env
+        if: matrix.arch == 'aarch64' && matrix.os == 'unknown-linux-gnu'
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update && sudo apt-get install -y g++-aarch64-linux-gnu
+          echo "CARGO_TARGET_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.arch }}-${{ matrix.os }}
+      - name: Upload to release
+        run: |
+          set -euo pipefail
+
+          curl \
+            -H 'accept: application/vnd.github+json' \
+            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'content-type: application/octet-stream' \
+            --data-binary "@$(find target/*/release/cloudformatious)" \
+            --fail \
+            "$(echo '${{ github.event.release.upload_url }}' | sed "s/{?name,label}/?name=$ASSET_NAME/")"
+        env:
+          ASSET_NAME: cloudformatious-${{ matrix.arch }}-${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "cloudformatious-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async_zip",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious-cli"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"


### PR DESCRIPTION
- 62df704 **ci: add release workflow**

  There are actually two workflows:
  
  1. `cache-osxcross` runs on any push to `master` to build and cache
     [osxcross], which is used to build OSX binaries. This is a separate
     workflow because release workflows run against the annotated tag, and
     so any caches generated in a release run could not actually be reused
     in future releases, whereas caches from the default branch are always
     usable.
  
  2. `release` runs... on release. It runs `cargo publish` (ripped from
     `wasdacraic/axum-sqlx-tx`), builds the CLI for a tasteful selection
     of targets, and uploads the built binaries to the release. This makes
     it possible to use `cloudformatious` without installing Rust.
  
  [osxcross]: https://github.com/tpoechtrager/osxcross

- efcd9bc **chore: bump version**

