### PR TITLE
Rustls

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,30 +10,28 @@ env:
   RUSTDOCFLAGS: -D warnings
 
 jobs:
-  update:
+  fetch:
     runs-on: ubuntu-20.04
     steps:
-      # Disabled while we depend on an old version of rusoto. Otherwise cargo update tries to bump
-      # the rusoto_credential dependency in aws_sso_flow, which breaks the build.
-      # - uses: actions/checkout@v2
-      # - name: Cargo cache
-      #   uses: actions/cache@v2
-      #   with:
-      #     key: ${{ github.sha }}
-      #     path: |
-      #       ~/.cargo/bin
-      #       ~/.cargo/git/db
-      #       ~/.cargo/registry/cache
-      #       ~/.cargo/registry/index
-      #       Cargo.lock
-      # - name: Update
-      #   run: cargo update --locked
-      - name: No-op
-        run: exit 0
+      - uses: actions/checkout@v2
+      - name: Cargo cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git/db
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            Cargo.lock
+      - name: Fetch
+        run: cargo fetch
+      - name: Check Cargo.lock is up to date
+        run: git diff --exit-code || (echo 'Cargo.lock needs updated' && exit 1)
 
   check:
     runs-on: ubuntu-20.04
-    needs: [update]
+    needs: [fetch]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -102,7 +100,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
-    needs: [update]
+    needs: [fetch]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,7 +50,7 @@ jobs:
           key: check-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Check
-        run: cargo check --all-targets
+        run: cargo check --all-targets --locked
 
   clippy:
     runs-on: ubuntu-20.04
@@ -73,7 +73,7 @@ jobs:
           key: check-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets --locked
 
   doc-check:
     runs-on: ubuntu-20.04
@@ -96,7 +96,7 @@ jobs:
           key: check-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Doc check
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps --locked
 
   test:
     runs-on: ubuntu-20.04
@@ -119,4 +119,4 @@ jobs:
           key: test-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Test
-        run: cargo test
+        run: cargo test --locked

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target ${{ matrix.arch }}-${{ matrix.os }}
+          args: --locked --release --target ${{ matrix.arch }}-${{ matrix.os }}
       - name: Upload to release
         run: |
           set -euo pipefail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,6 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "lazy_static",
  "pin-project-lite",
  "tokio",
@@ -866,21 +865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,19 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,24 +1232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,49 +1276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
-name = "openssl"
-version = "0.10.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -1434,12 +1348,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-macro-error"
@@ -1897,16 +1805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,12 +1962,6 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "cloudformatious-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async_zip",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious-cli"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/main.rs"
 [dependencies]
 async_zip = { version = "0.0.9", default-features = false, features = ["deflate"] }
 atty = "0.2.14"
-aws-config = { version = "0.49.0", default-features = false, features = ["client-hyper", "native-tls", "rt-tokio"] }
-aws-sdk-s3 = { version = "0.19", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-config = { version = "0.49.0", default-features = false, features = ["client-hyper", "rt-tokio", "rustls"] }
+aws-sdk-s3 = { version = "0.19", default-features = false, features = ["rt-tokio", "rustls"] }
 aws-types = "0.49.0"
-aws_sso_flow = { version = "0.3.1", default-features = false, features = ["aws-sdk", "native-tls"] }
+aws_sso_flow = { version = "0.3.1", default-features = false, features = ["aws-sdk", "rustls"] }
 base64 = "0.13.0"
 chrono = { version = "0.4.22", default-features = false }
 clap = { version = "3.2.20", features = ["derive", "env"] }


### PR DESCRIPTION
- 58ce044 **chore: switch to rustls for dependencies**

  We would have switched to rustls at some point anyway, but something has
  gone awry when updating to the aws-sdk such that the native-tls
  (openssl) builds are no longer succeeding in CI.

- a0737c3 **ci: re-enable `update` job in `PR` workflow**

  The job regenerates the lockfile and fails the build if there are any
  changes.

- 1c4aac9 **ci: use locked dependencies for all CI `cargo` invocations**

  Ths ensures we're actually building/linting/testing what we committed.

- f99b1f6 **chore: bump version**

