### PR TITLE
`ROLLBACK_COMPLETE` recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "cloudformatious"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe6e446ff27c581b6ff7d98399228feb955c25497aa0e4a9e740d4e8cddb185"
+checksum = "179ce26694e93e26f0f8551e408010ba15c16b86aaf19e2841bf27ceea438155"
 dependencies = [
  "async-stream",
  "aws-config",
@@ -1291,7 +1291,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b25af4ef94a8528b41fb49a696e361dc6ef975c782417268072d987ac327964"
 dependencies = [
+ "once_cell",
  "parse-display-derive",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "cloudformatious-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async_zip",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious-cli"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.13.0"
 chrono = { version = "0.4.22", default-features = false }
 clap = { version = "4.0.18", features = ["derive", "env"] }
 clap_complete = "4.0.3"
-cloudformatious = "0.2.0"
+cloudformatious = "0.5.0"
 colored = "2.0.0"
 futures-util = "0.3.24"
 hyper = { version = "0.14.20", features = ["stream"] }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -81,7 +81,7 @@ impl Client {
             .body(body.into())
             .bucket(request.bucket)
             .content_length(meta.len().try_into().expect("file is insanely large"))
-            .content_md5(base64::encode(&content_md5.0))
+            .content_md5(base64::encode(content_md5.0))
             .key(&key)
             .send()
             .await

--- a/test/fixtures/failing.yaml
+++ b/test/fixtures/failing.yaml
@@ -1,0 +1,4 @@
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties: {}


### PR DESCRIPTION
- a0fbd12 **chore: upgrade `cloudformatious`**

  This required an update to the `ApplyStackInput` struct.

- a64ec45 **feat: implement recovery from `ROLLBACK_COMPLETE`**

  This adds general "recovery" machinery to the `apply_stack` command, and
  a specific implementation for `ROLLBACK_COMPLETE` (by deleting the stack
  before re-running `apply_stack`).

- 1fa095f **chore: fix clippy lint**


- fde3d0c **chore: bump version**

