### PR TITLE
Use relative path in zip entries

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -154,7 +154,7 @@ async fn package_zip(target: &Target<'_>) -> Result<File, Error> {
         let path = path.or_else(|error| upload_err(target, format!("couldn't read: {error}")))?;
 
         let file_name = path
-            .file_name()
+            .strip_prefix(&target.path)
             .expect("file must have file name")
             .to_string_lossy()
             .into_owned();


### PR DESCRIPTION
- e55a6e6 **fix: use relative path in zip entries**

  This fixes packaging directories with subdirectories, since we were
  previously using only the file name.

- 6d10963 **chore: fix new clippy lint**

  The original complaint was unnecesarily borrowing `path` for the call to
  `std::fs::read_dir`, which led to realising that `scandir` didn't need
  to take ownership.
