### PR TITLE
Support packaging of CloudFormation stack's `TemplateURL`s

### DIFF
--- a/test/fixtures/nested.yaml
+++ b/test/fixtures/nested.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy a VPC.
+
+Parameters:
+  VpcCidrBlock:
+    Description: The CIDR range to use for the VPC.
+    Type: String
+    Default: 10.0.0.0/16
+
+Resources:
+  Vpc:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        VpcCidrBlock: !Ref VpcCidrBlock
+      TemplateURL: vpc.yaml


### PR DESCRIPTION
- 078bcfb **refactor: indirect `Target` path via `Src` enum**

  This is a trivial preparatory refactor to create a space for adding git
  repository handling.

- 9aa3e4b **feat: support packaging of CloudFormation stack's `TemplateURL`s**

  The `TemplateURL` of `AWS::CloudFormation::Stack` resources is now a
  packageable property. This required adding a `strategy` field to the
  `PackageableProperty` struct to indicate how the local path should be
  processed, since the S3 reference for `TemplateURL` must point to a
  plain file (i.e. rather than a zip file).
  
  Technically a `zip: bool` field would have been sufficient for now, but
  the `PackageStrategy` enum is more extensible and arguably clearer.
