### PR TITLE
Configure `aarch64-unknown-linux-*` cross-compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[env]
+CC_aarch64_unknown_linux_musl = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
- 1a7289b **fix: configure `aarch64-unknown-linux-*` cross-compilation**

  Sadly, simply installing `gcc-aarch64-linux-gnu` isn't quite enough to
  cross-compile from `x86_64` linux to `aarch64`, we also need to:
  
  - Override `cc` for the `aarch-64-unknown-linux-musl` target (there's no
    `gcc-aarch64-linux-musl` package).
  - Override the linker for both targets (for some reason `cargo` doesn't
    apply the same default behaviour here as it does for `cc`).
